### PR TITLE
CI: Add arm64-dariwn coverage on macos-14

### DIFF
--- a/.github/workflows/gem-install.yml
+++ b/.github/workflows/gem-install.yml
@@ -25,6 +25,7 @@ jobs:
             "x64-mingw32",
             "x64-mingw-ucrt",
             "x86_64-darwin",
+            "arm64-darwin",
             "x86_64-linux",
             "arm-linux",
           ]
@@ -104,9 +105,9 @@ jobs:
               tailwindcss --help
             "
 
-  darwin-install:
+  darwin-x86_64-install:
     needs: ["package"]
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: ruby/setup-ruby@v1
         with:
@@ -114,6 +115,21 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: gem-x86_64-darwin
+          path: pkg
+      - run: "gem install pkg/jekyll-tailwindcss-*.gem"
+      - run: "tailwindcss --help"
+
+
+  darwin-arm64-install:
+    needs: ["package"]
+    runs-on: macos-14
+    steps:
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+      - uses: actions/download-artifact@v3
+        with:
+          name: gem-arm64-darwin
           path: pkg
       - run: "gem install pkg/jekyll-tailwindcss-*.gem"
       - run: "tailwindcss --help"

--- a/spec/integration/user_journey_test.sh
+++ b/spec/integration/user_journey_test.sh
@@ -22,6 +22,9 @@ bundle exec jekyll -v
 bundle exec jekyll new test-site --skip-bundle
 pushd test-site
 
+# trying a fix from https://github.com/Maher4Ever/wdm/issues/27
+gem install wdm -- --with-cflags=-Wno-implicit-function-declaration
+
 # make sure to use the same version of jekyll
 bundle remove jekyll
 bundle add jekyll --skip-install


### PR DESCRIPTION
and pin x86_64-darwin to macos-13

See https://github.com/rails/tailwindcss-rails/pull/351