### PR TITLE
Allow to customize tailwind config location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+* Location of `tailwind.config.js` can be specified in `_config.yml`
+
 ### Notable changes
 
 * The upstream `tailwindcss` executable has been extracted from this gem into a new dependency, `tailwindcss-ruby`.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ Any `*.css` file processed by jekyll [^1] that contains the `@tailwind` [directi
 
 [^1]: Jekyll will process any file that begins with yaml [frontmatter](https://jekyllrb.com/docs/front-matter/)
 
+### Configuration
+
+Location of the `tailwind.config.js` file can be configured in `_config.yml`:
+
+``` yaml
+tailwindcss:
+  config: './tailwind.config.js' # this is the default location
+```
+
 ### Examples
 
 

--- a/lib/jekyll/converters/tailwindcss.rb
+++ b/lib/jekyll/converters/tailwindcss.rb
@@ -21,7 +21,9 @@ module Jekyll
         dev_mode = Jekyll.env == "development"
         Jekyll.logger.info "Jekyll Tailwind:", "Generating #{dev_mode ? "" : "minified "}CSS"
 
-        compile_command = ::Tailwindcss::Commands.compile_command(debug: dev_mode).join(" ")
+        compile_command = ::Tailwindcss::Commands
+          .compile_command(debug: dev_mode, config: config_location)
+          .join(" ")
 
         output, error = nil
         Open3.popen3(tailwindcss_env_options, compile_command) do |stdin, stdout, stderr, _wait_thread|
@@ -44,6 +46,10 @@ module Jekyll
         # Without this ENV you'll get a warning about `Browserslist: caniuse-lite is outdated`
         # Since we're using the CLI, we can't update the data, so we ignore it.
         {"BROWSERSLIST_IGNORE_OLD_DATA" => "1"}
+      end
+
+      def config_location
+        @config.dig("tailwindcss", "config") || "./tailwind.config.js"
       end
     end
   end

--- a/lib/tailwindcss/commands.rb
+++ b/lib/tailwindcss/commands.rb
@@ -3,12 +3,12 @@ require "tailwindcss/ruby"
 module Tailwindcss
   module Commands
     class << self
-      def compile_command(debug: false, **kwargs)
+      def compile_command(debug: false, config: nil, **kwargs)
         command = [
           Tailwindcss::Ruby.executable(**kwargs),
-          "--input", "-",
-          "--config", "./tailwind.config.js"
+          "--input", "-"
         ]
+        command += ["--config", config] if config
 
         command << "--minify" unless debug
 

--- a/spec/jekyll/converters/tailwindcss_spec.rb
+++ b/spec/jekyll/converters/tailwindcss_spec.rb
@@ -50,8 +50,8 @@ RSpec.describe Jekyll::Converters::Tailwindcss do
     let(:compile_arguments) { ["--input", "-", "--config", "./tailwind.config.js"] }
 
     before do
-      allow(::Tailwindcss::Commands).to receive(:compile_command).with(debug: true).and_return(["tailwindcss", *compile_arguments])
-      allow(::Tailwindcss::Commands).to receive(:compile_command).with(debug: false).and_return(["tailwindcss", *compile_arguments, "--minify"])
+      allow(::Tailwindcss::Commands).to receive(:compile_command).with(debug: true, config: "./tailwind.config.js").and_return(["tailwindcss", *compile_arguments])
+      allow(::Tailwindcss::Commands).to receive(:compile_command).with(debug: false, config: "./tailwind.config.js").and_return(["tailwindcss", *compile_arguments, "--minify"])
       allow(Jekyll).to receive(:env).and_return(jekyll_env)
       allow(Jekyll.logger).to receive(:info)
       allow(Open3).to receive(:popen3).with(env_options, compile_command_regex).and_yield(mock_stdin, mock_stdout, mock_stderr, nil)
@@ -88,6 +88,22 @@ RSpec.describe Jekyll::Converters::Tailwindcss do
         expect(mock_stderr).to receive(:read)
 
         expect(converter.convert(tailwindcss_content)).to eq(css_content)
+      end
+    end
+
+    context "when custom config location is specified" do
+      let(:compile_command_regex) { /--config other_location/ }
+
+      it "uses custom config location" do
+        converter.instance_variable_set(:@config, {
+          "tailwindcss" => {
+            "config" => "other_location"
+          }
+        })
+
+        allow(::Tailwindcss::Commands).to receive(:compile_command).with(debug: true, config: "other_location").and_return(["tailwindcss", "--input", "--config", "other_location"])
+
+        converter.convert(tailwindcss_content)
       end
     end
   end

--- a/spec/tailwindcss/commands_spec.rb
+++ b/spec/tailwindcss/commands_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Tailwindcss::Commands do
 
   describe ".compile_command" do
     it "receives arguments" do
-      args = ["--input", "-", "--config", "./tailwind.config.js", "--minify"]
+      args = ["--input", "-", "--minify"]
 
       command_args = described_class.compile_command.slice(1...)
       expect(command_args).to eq(args)
@@ -28,6 +28,13 @@ RSpec.describe Tailwindcss::Commands do
         command_args = described_class.compile_command
         expect(command_args).to include("--postcss")
         expect(command_args).to include(postcss_path)
+      end
+    end
+
+    context "when config is passed" do
+      it "includes config param with the passed value" do
+        expect(described_class.compile_command(config: "other.config.js"))
+          .to include("--config", "other.config.js")
       end
     end
   end


### PR DESCRIPTION
Hi. Thanks for the gem!

This PR allows users to configure the location of the Tailwind config file in `_config.yml`.

This can be useful for Jekyll themes which depend on `jekyll-tailwindcss` and provide their own `tailwind.config.js`.

More context follows, if you are wondering why this might be needed.

I am making a gem-based Jekyll theme which depends on this gem. Because `jekyll-tailwindcss` is a dependency of my theme, `jekyll-tailwindcss` is automatically added as a plugin if my theme is used. However, users of my theme need to add `tailwind.config.js` to their site and I want to avoid this.

I plan to use `jekyll-gem-resolver` in combination with this PR like this in theme's config:
```yml
tailwind:
  config: 'gem:my-gem-based-theme/tailwind.config.js'

gem_resolver:
  transform:
    - tailwind.config
```

I'd rather avoid adding one more dependency but I don't know how else I could point Tailwind CLI to the vendored `tailwind.config.js`.