### PR TITLE
Expand the tailwind v4 file matcher

### DIFF
--- a/lib/jekyll/converters/tailwindcss.rb
+++ b/lib/jekyll/converters/tailwindcss.rb
@@ -16,7 +16,7 @@ module Jekyll
       end
 
       def convert(content)
-        return content unless /@tailwind|@import ['"]tailwindcss['"]/i.match?(content)
+        return content unless /@tailwind|@import ['"]tailwindcss/i.match?(content)
         if content.include?("@tailwind") && config_path.nil?
           Jekyll.logger.error "Jekyll Tailwind:", "to use tailwind v3 you need to include a config path in _config.yml"
           return content

--- a/spec/jekyll/converters/tailwindcss_spec.rb
+++ b/spec/jekyll/converters/tailwindcss_spec.rb
@@ -67,6 +67,27 @@ RSpec.describe Jekyll::Converters::Tailwindcss do
       end
     end
 
+    context "When skipping preflight" do
+      # https://tailwindcss.com/docs/preflight#disabling-preflight
+      let(:tailwindcss_content) do
+        <<~TAILWINDCSS
+          @layer theme, base, components, utilities;
+          @import "tailwindcss/theme.css" layer(theme);
+          @import "tailwindcss/utilities.css" layer(utilities);
+        TAILWINDCSS
+      end
+
+      it "calls the tailwind CLI" do
+        expect(Jekyll.logger).to receive(:info).with("Jekyll Tailwind:", "Generating CSS")
+        expect(Jekyll.logger).not_to receive(:warn)
+        expect(mock_stdin).to receive(:write).with(tailwindcss_content)
+        expect(mock_stdout).to receive(:read)
+        expect(mock_stderr).to receive(:read)
+
+        expect(converter.convert(tailwindcss_content)).to eq(css_content)
+      end
+    end
+
     context "when using TailwindCSS v3" do
       let(:tailwindcss_content) do
         <<~TAILWINDCSS


### PR DESCRIPTION
### Problem

A valid thing to do in Tailwind v4 is to disable preflight. https://tailwindcss.com/docs/preflight#disabling-preflight

The matcher regex was not recognizing CSS files that look like
 ```css
@layer theme, base, components, utilities;
@import "tailwindcss/theme.css" layer(theme);
@import "tailwindcss/utilities.css" layer(utilities);
```

### Solutino

change the regex to match any `@import "tailwindcss....` directive