### PR TITLE
Handle plugins in v3 detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Support importing official plugins in CSS for v4 [#22](https://github.com/vormwald/jekyll-tailwindcss/pull/22) @imustafin
+
 ## [0.6.1] - 2025-02-13
 
 - Expand the matcher to match additional valid tailwindcss imports [#21](https://github.com/vormwald/jekyll-tailwindcss/pull/21)

--- a/lib/jekyll/converters/tailwindcss.rb
+++ b/lib/jekyll/converters/tailwindcss.rb
@@ -17,7 +17,7 @@ module Jekyll
 
       def convert(content)
         return content unless /@tailwind|@import ['"]tailwindcss/i.match?(content)
-        if content.include?("@tailwind") && config_path.nil?
+        if config_path.nil? && tailwind_v3_syntax?(content)
           Jekyll.logger.error "Jekyll Tailwind:", "to use tailwind v3 you need to include a config path in _config.yml"
           return content
         end
@@ -45,6 +45,12 @@ module Jekyll
       end
 
       private
+
+      def tailwind_v3_syntax?(content)
+        return false if content.include?("@plugin")
+
+        content.include?("@tailwind")
+      end
 
       def tailwindcss_env_options
         # Without this ENV you'll get a warning about `Browserslist: caniuse-lite is outdated`

--- a/spec/jekyll/converters/tailwindcss_spec.rb
+++ b/spec/jekyll/converters/tailwindcss_spec.rb
@@ -88,6 +88,24 @@ RSpec.describe Jekyll::Converters::Tailwindcss do
       end
     end
 
+    context "when using official plugins" do
+      let(:tailwindcss_content) do
+        # Example installation configuration for
+        # https://github.com/tailwindlabs/tailwindcss-typography
+        <<~TAILWINDCSS
+          @import "tailwindcss";
+          @plugin "@tailwindcss/typography";
+        TAILWINDCSS
+      end
+
+      it "does not produce errors" do
+        expect(Jekyll.logger).not_to receive(:error).with("Jekyll Tailwind:", /v3/)
+        expect(Jekyll.logger).to receive(:info).with("Jekyll Tailwind:", "Generating CSS")
+
+        converter.convert(tailwindcss_content)
+      end
+    end
+
     context "when using TailwindCSS v3" do
       let(:tailwindcss_content) do
         <<~TAILWINDCSS


### PR DESCRIPTION
Hi! Thanks for the Tailwind v4 update!

Unfortunately, there is an error when v4 is used without a config file but with an official plugin.

According to the installation instructions, typography plugin https://github.com/tailwindlabs/tailwindcss-typography is imported as:
```css
@import "tailwindcss";
@plugin "@tailwindcss/typography";
```
Which has the substring `@tailwindcss` which triggers the v3 check.

If needed, I can make the check a bit smarter, but maybe it is ok as it is. 