### PR TITLE
Fix "No such file or directory" on Windows

### DIFF
--- a/jekyll-tailwindcss.gemspec
+++ b/jekyll-tailwindcss.gemspec
@@ -16,4 +16,5 @@ Gem::Specification.new do |spec|
   spec.bindir = "exe"
   spec.require_paths = ["lib"]
   spec.add_dependency "tailwindcss-ruby"
+  spec.add_dependency "os"
 end

--- a/lib/tailwindcss/commands.rb
+++ b/lib/tailwindcss/commands.rb
@@ -1,11 +1,14 @@
 require "tailwindcss/ruby"
+require "os"
 
 module Tailwindcss
   module Commands
     class << self
       def compile_command(debug: false, config_path: nil, postcss_path: nil, **kwargs)
+        executable = Tailwindcss::Ruby.executable(**kwargs).to_s
+
         command = [
-          Tailwindcss::Ruby.executable(**kwargs),
+          "#{(OS.windows? && executable.include?(" ")) ? "\"%s\"" : "%s"}" % executable,
           "--input", "-"
         ]
         command += ["--config", config_path] if config_path

--- a/spec/jekyll/converters/tailwindcss_spec.rb
+++ b/spec/jekyll/converters/tailwindcss_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Jekyll::Converters::Tailwindcss do
     let(:mock_stdout) { instance_double(IO, read: css_content) }
     let(:mock_stderr) { instance_double(IO, read: error_message) }
 
-    let(:compile_command_regex) { /.+\/tailwindcss --input -$/ }
+    let(:compile_command_regex) { /.+\/tailwindcss"? --input -$/ }
     let(:compile_arguments) { ["--input", "-"] }
 
     before do
@@ -121,7 +121,7 @@ RSpec.describe Jekyll::Converters::Tailwindcss do
           }
         }
       end
-      let(:compile_command_regex) { /.+\/tailwindcss --input - --config tailwind.config.js$/ }
+      let(:compile_command_regex) { /.+\/tailwindcss"? --input - --config tailwind.config.js$/ }
       let(:compile_arguments) { ["--input", "-", "--config", "./tailwind.config.js"] }
 
       it "calls the tailwindcss CLI" do
@@ -150,7 +150,7 @@ RSpec.describe Jekyll::Converters::Tailwindcss do
             }
           }
         end
-        let(:compile_command_regex) { /.+\/tailwindcss --input - --config other_location$/ }
+        let(:compile_command_regex) { /.+\/tailwindcss"? --input - --config other_location$/ }
         let(:compile_arguments) { ["--input", "-", "--config", "./other_location"] }
 
         it "uses custom config location" do


### PR DESCRIPTION
I was getting "No such file or directory" on Windows due to my username containing a space:

![Error example on PowerShell](https://github.com/user-attachments/assets/46108701-5f99-48a0-a4f4-aeb145225c37)

The PR fixes this error by wrapping the executable path with quotes if needed (and only if on Windows).
